### PR TITLE
Tell composer that this polyfill provides an `ext-newrelic` compatible implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,14 @@
             "email": "gadelat@gmai.com"
         }
     ],
+    "provide": {
+        "ext-newrelic": "*"
+    },
     "require": {
         "php": ">=8.0"
     },
     "suggest": {
-        "ext-newrelic": "Install the New Relic PHP agent on your system"
+        "ext-newrelic": "Install the New Relic extension to trakc performance."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change:
1. Tells composer that this package provides a compatible replacement for `ext-newrelic`
2. Changes the suggestion output to be more clear that installing the extension provides tracking

See the equivalent in `symfony/polyfill-mbstring`: https://github.com/symfony/polyfill-mbstring/blob/1.x/composer.json#L21-L23